### PR TITLE
Relax Fn requirement for a function that will be called only once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ impl<C: Send + 'static, E: Send + 'static> NetworkBuilder<C, E> {
 
     pub fn spawn_machine<B, F>(&mut self, builder: B) -> Ipv4Addr
     where
-        B: Fn(mpsc::Receiver<C>, mpsc::Sender<E>) -> F + Send + 'static,
+        B: FnOnce(mpsc::Receiver<C>, mpsc::Sender<E>) -> F + Send + 'static,
         F: Future<Output = ()> + Send + 'static,
     {
         let (iface_a, iface_b) = wire();


### PR DESCRIPTION
This makes the API much easier to use.

------

Hey! I'm discovering netsim-embed (after noticing it exists from the netsim crate issue tracker and having failed to use netsim that requires a too-old version of libc), and it looks awesome :D

I've just hit a problem that could be easily fixed in netsim-embed, by taking FnOnce instead of Fn. Unless there's some spooky action-at-a-distance unsafe code, this change should be legitimate, and makes programming much easier by not requiring arcs and clones everywhere.

What do you think about that change? :)