### PR TITLE
Format machine's stdout printed messages

### DIFF
--- a/machine/src/lib.rs
+++ b/machine/src/lib.rs
@@ -246,7 +246,7 @@ where
                             break;
                         }
                     } else {
-                        println!("{}", ev);
+                        println!("{} (stdout): {}", id, ev);
                     }
                 }
                 Result::Ok(())


### PR DESCRIPTION
Makes it easier to debug / get an overview when running with multiple machines.