### PR TITLE
export NAT port forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,7 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "netsim-embed"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-global-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cli", "core", "machine", "nat", "router", "."]
 
 [package]
 name = "netsim-embed"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["David Craven <david@craven.ch>"]
 edition = "2018"
 description = "Network simulator."

--- a/core/src/range.rs
+++ b/core/src/range.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use thiserror::Error;
 
 /// A range of IPv4 addresses with a common prefix
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Ipv4Range {
     addr: Ipv4Addr,
     bits: u8,

--- a/machine/src/lib.rs
+++ b/machine/src/lib.rs
@@ -229,6 +229,7 @@ where
 
             let ctrl_task = async {
                 while let Some(ctrl) = ctrl.next().await {
+                    log::debug!("{} CTRL {:?}", id, ctrl);
                     match ctrl {
                         IfaceCtrl::Up => iface.get_ref().put_up()?,
                         IfaceCtrl::Down => iface.get_ref().put_down()?,
@@ -303,7 +304,7 @@ where
                 let mut buf = Vec::with_capacity(4096);
                 while let Some(cmd) = cmd.next().await {
                     buf.clear();
-                    log::trace!("{}", cmd);
+                    log::debug!("{} {}", id, cmd);
                     writeln!(buf, "{}", cmd)?;
                     stdin.write_all(&buf).await?;
                 }

--- a/machine/src/lib.rs
+++ b/machine/src/lib.rs
@@ -260,7 +260,7 @@ where
                     if buf[0] >> 4 != 4 {
                         continue;
                     }
-                    log::debug!("{} (reader): sending packet", id);
+                    log::trace!("{} (reader): sending packet", id);
                     let mut bytes = buf[..n].to_vec();
                     if let Some(mut packet) = Packet::new(&mut bytes) {
                         packet.set_checksum();
@@ -277,7 +277,7 @@ where
 
             let writer_task = async {
                 while let Some(packet) = rx.next().await {
-                    log::debug!("{} (writer): received packet", id);
+                    log::trace!("{} (writer): received packet", id);
                     // can error if the interface is down
                     if let Ok(n) = iface.write_with(|iface| iface.send(&packet)).await {
                         if n == 0 {

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -17,6 +17,7 @@ enum RouterCtrl {
 
 #[derive(Debug)]
 pub struct Ipv4Router {
+    #[allow(unused)]
     addr: Ipv4Addr,
     ctrl: mpsc::UnboundedSender<RouterCtrl>,
 }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -130,9 +130,9 @@ fn forward_packet(
         for route in routes {
             if route.dest().contains(dest) || dest.is_broadcast() || dest.is_multicast() {
                 if !*en {
-                    log::debug!("router {}: route {:?} disabled", addr, route);
+                    log::trace!("router {}: route {:?} disabled", addr, route);
                 } else {
-                    log::debug!("router {}: routing packet on route {:?}", addr, route);
+                    log::trace!("router {}: routing packet on route {:?}", addr, route);
                     let _ = tx.unbounded_send(bytes.clone());
                     forwarded = true;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl<C, E> Default for Netsim<C, E> {
 impl<C, E> Netsim<C, E>
 where
     C: Display + Send + 'static,
-    E: FromStr + Send + 'static,
+    E: FromStr + Display + Send + 'static,
     E::Err: std::fmt::Debug + Display + Send + Sync,
 {
     pub fn new() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,23 +222,11 @@ impl Network {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct NatConfig {
     pub hair_pinning: bool,
     pub symmetric: bool,
     pub blacklist_unrecognized_addrs: bool,
     pub restrict_endpoints: bool,
     pub forward_ports: Vec<(Protocol, u16, SocketAddrV4)>,
-}
-
-impl Default for NatConfig {
-    fn default() -> Self {
-        Self {
-            hair_pinning: false,
-            symmetric: false,
-            blacklist_unrecognized_addrs: false,
-            restrict_endpoints: false,
-            forward_ports: Vec::new(),
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use async_process::Command;
 use futures::prelude::*;
 pub use libpacket::*;
 use netsim_embed_core::*;
-pub use netsim_embed_core::{DelayBuffer, Ipv4Range};
+pub use netsim_embed_core::{DelayBuffer, Ipv4Range, Protocol};
 pub use netsim_embed_machine::{unshare_user, Machine, MachineId, Namespace};
 use netsim_embed_nat::*;
 use netsim_embed_router::*;


### PR DESCRIPTION
Unfortunately, this makes NatConfig `!Copy`, which is a breaking change. @dvc94ch if you’d like this to be a non-breaking extension, we can also pass the ports via a new method, WDYT?
